### PR TITLE
Refactor: Make convert_timestamps_to_str recursive

### DIFF
--- a/actions/lib/helpers.py
+++ b/actions/lib/helpers.py
@@ -36,10 +36,10 @@ def get_issue_url(api_client, issue_id, portal_url):
     url = None
     try:
         response = api_client.execute_graphql_dict(query=q, variables=variables)
-        issue = response["data"]["tdh_issue"]
+        issue = response["tdh_issue"]
         if issue and issue.get("isPublished"):
             url = urljoin(portal_url, f"tdh/issues/{issue_id}")
-    except PortalAPIError:
+    except (PortalAPIError, KeyError):
         pass
 
     return url

--- a/actions/lib/helpers.py
+++ b/actions/lib/helpers.py
@@ -45,13 +45,17 @@ def get_issue_url(api_client, issue_id, portal_url):
     return url
 
 
-def convert_timestamps_to_str(dictionary: dict) -> dict:
-    for k, v in dictionary.items():
-        try:
-            dictionary[k] = v.strftime('%Y-%m-%dT%H:%M:%S.%fZ')
-        except AttributeError:
-            pass
-    return dictionary
+def convert_timestamps_to_str(json_element):
+    if isinstance(json_element, dict):
+        for k, v in json_element.items():
+            try:
+                json_element[k] = v.strftime('%Y-%m-%dT%H:%M:%S.%fZ')
+            except AttributeError:
+                convert_timestamps_to_str(json_element[k])
+    elif isinstance(json_element, list):
+        for item in json_element:
+            convert_timestamps_to_str(item)
+    return json_element
 
 
 def get_query_string():

--- a/actions/lib/helpers.py
+++ b/actions/lib/helpers.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2021, DCSO GmbH
 
 import os
+from typing import Union
 from urllib.parse import urljoin
 
 from dcso.portal import APIClient, PortalAPIError
@@ -45,7 +46,12 @@ def get_issue_url(api_client, issue_id, portal_url):
     return url
 
 
-def convert_timestamps_to_str(json_element):
+def convert_timestamps_to_str(json_element: Union[dict, list]) -> Union[dict, list]:
+    """Converts timestamps in JSON object/array from Python Datetime to str
+
+    This methods recursively iterates through a given JSON object or array and tries to convert every element
+    into a string of the format %Y-%m-%dT%H:%M:%S.%fZ
+    """
     if isinstance(json_element, dict):
         for k, v in json_element.items():
             try:

--- a/actions/set_issue_cursor.py
+++ b/actions/set_issue_cursor.py
@@ -9,7 +9,7 @@ from lib.helpers import get_key_client
 
 
 class SetIssueCursor(Action):
-    def run(self, value):
+    def run(self, value=""):
         try:
             key_client = get_key_client()
 

--- a/tests/fixtures/tdh_issue_api_response.json
+++ b/tests/fixtures/tdh_issue_api_response.json
@@ -1,8 +1,6 @@
 {
-  "data": {
-    "tdh_issue": {
-      "id": "7776bd11-d77f-477c-9972-0c777c5fad18",
-      "isPublished": true
-    }
+  "tdh_issue": {
+    "id": "7776bd11-d77f-477c-9972-0c777c5fad18",
+    "isPublished": true
   }
 }


### PR DESCRIPTION
The old method to convert python timestamps to strings was not recursive and only operating on the highest level of the json.
This resulted in timestamps not being converted in nested structures. 

The improved method recursively iterates through every element of the json and attempts to convert  the element into a timestamp-string.

Further improvements and fixes:
 - access data correctly in get_issue_url()
 - add default for value in set_issue_cursor to avoid conflicts with modified stackstorm versions